### PR TITLE
Add logging config to s3 buckets

### DIFF
--- a/groups/promo-infrastructure/locals.tf
+++ b/groups/promo-infrastructure/locals.tf
@@ -5,7 +5,6 @@ locals {
   s3_promo_web_hosting_bucket      = "${var.aws_account}.${var.aws_region}.promo-resources.ch.gov.uk"
   s3_origin_id                     = "promo"
   s3_promo_cf_logs_bucket          = "${var.aws_account}.${var.aws_region}.promo-s3-cf-logs"
-  s3_promo_web_hosting_logs_bucket = "${var.aws_account}.${var.aws_region}.promo-s3-web-hosting-logs"
   security_s3                      = data.vault_generic_secret.security_s3.data
 
   kms_customer_master_keys = {

--- a/groups/promo-infrastructure/main.tf
+++ b/groups/promo-infrastructure/main.tf
@@ -35,10 +35,18 @@ provider "vault" {
 ## S3 access logging
 ####################################################################################################
 
-module "s3_access_logging" {
+module "s3_access_logging_website" {
   source = "git@github.com:companieshouse/terraform-modules//aws/s3_access_logging?ref=tags/1.0.264"
 
   aws_account           = var.aws_account
   aws_region            = var.aws_region
-  source_s3_bucket_name = module.s3_promo_web_hosting_bucket.s3_bucket_id
+  source_s3_bucket_name = local.s3_promo_web_hosting_bucket
+}
+
+module "s3_access_logging_cloudfront" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/s3_access_logging?ref=tags/1.0.264"
+
+  aws_account           = var.aws_account
+  aws_region            = var.aws_region
+  source_s3_bucket_name = local.s3_promo_cf_logs_bucket
 }

--- a/groups/promo-infrastructure/main.tf
+++ b/groups/promo-infrastructure/main.tf
@@ -30,3 +30,15 @@ provider "vault" {
     }
   }
 }
+
+####################################################################################################
+## S3 access logging
+####################################################################################################
+
+module "s3_access_logging" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/s3_access_logging?ref=tags/1.0.264"
+
+  aws_account           = var.aws_account
+  aws_region            = var.aws_region
+  source_s3_bucket_name = module.s3_promo_web_hosting_bucket.s3_bucket_id
+}

--- a/groups/promo-infrastructure/s3-cloudfront-logs.tf
+++ b/groups/promo-infrastructure/s3-cloudfront-logs.tf
@@ -51,10 +51,6 @@ module "cloudfront_logs_bucket" {
     }
   ]
 
-  logging = {
-    target_bucket = local.s3_promo_cf_logs_bucket
-  }
-
   tags = {
     "Name" = "${var.application}-cf-logs"
     "Env"  = var.environment

--- a/groups/promo-infrastructure/s3-website-hosting.tf
+++ b/groups/promo-infrastructure/s3-website-hosting.tf
@@ -104,11 +104,3 @@ resource "aws_s3_bucket_policy" "s3_promo_web_hosting_bucket_policy" {
 }
 POLICY
 }
-
-module "s3_access_logging" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/s3_access_logging?ref=tags/1.0.262"
-
-  aws_account         = var.aws_account
-  aws_region          = var.aws_region
-  source_s3_bucket_id = module.s3_promo_web_hosting_bucket.s3_bucket_id
-}

--- a/groups/promo-infrastructure/s3-website-hosting.tf
+++ b/groups/promo-infrastructure/s3-website-hosting.tf
@@ -104,3 +104,11 @@ resource "aws_s3_bucket_policy" "s3_promo_web_hosting_bucket_policy" {
 }
 POLICY
 }
+
+module "s3_access_logging" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/s3_access_logging?ref=tags/1.0.262"
+
+  aws_account         = var.aws_account
+  aws_region          = var.aws_region
+  source_s3_bucket_id = module.s3_promo_web_hosting_bucket.s3_bucket_id
+}


### PR DESCRIPTION
Adds s3 access logging to the promo website hosting bucket and updates the log destination for access logging on the cloudfront logs bucket, as that was logging to itself.

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2825
