### PR TITLE
Bump aws s3-bucket module version to 3.0.1

### DIFF
--- a/groups/promo-infrastructure/s3-cloudfront-logs.tf
+++ b/groups/promo-infrastructure/s3-cloudfront-logs.tf
@@ -1,6 +1,6 @@
 module "cloudfront_logs_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "2.1.0"
+  version = "3.0.1"
 
   bucket        = local.s3_promo_cf_logs_bucket
   attach_policy = "false"
@@ -41,12 +41,17 @@ module "cloudfront_logs_bucket" {
   grant = [
     {
       type        = "Group"
-      permissions = ["READ_ACP", "WRITE"]
+      permission  = "READ_ACP"
+      uri         = "http://acs.amazonaws.com/groups/s3/LogDelivery"
+    },
+    {
+      type        = "Group"
+      permission  = "WRITE"
       uri         = "http://acs.amazonaws.com/groups/s3/LogDelivery"
     },
     {
       type        = "CanonicalUser"
-      permissions = ["FULL_CONTROL"]
+      permission  = "FULL_CONTROL"
       id          = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
     }
   ]

--- a/groups/promo-infrastructure/s3-website-hosting.tf
+++ b/groups/promo-infrastructure/s3-website-hosting.tf
@@ -1,6 +1,6 @@
 module "s3_promo_web_hosting_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "2.1.0"
+  version = "3.0.1"
 
   bucket = local.s3_promo_web_hosting_bucket
   acl    = "private"
@@ -40,40 +40,41 @@ module "s3_promo_web_hosting_bucket" {
     index_document = "index.shtml"
     error_document = "error.shtml"
 
-    routing_rules = <<EOF
-[
-  {
-    "Condition": {
-        "KeyPrefixEquals": "arefiling/"
-    },
-    "Redirect": {
-        "HostName": "gov.uk",
-        "Protocol": "https",
-        "ReplaceKeyPrefixWith": "file-your-confirmation-statement-with-companies-house/"
-    }
-  },
-  {
-    "Condition": {
-        "KeyPrefixEquals": "freedominformation/freedominfo.shtml"
-    },
-    "Redirect": {
-        "HostName": "gov.uk",
-        "Protocol": "https",
-        "ReplaceKeyPrefixWith": "government/organisations/companies-house/about/personal-information-charter"
-    }
-  },
-  {
-    "Condition": {
-        "KeyPrefixEquals": "pressDesk/introduction.shtml"
-    },
-    "Redirect": {
-        "HostName": "gov.uk",
-        "Protocol": "https",
-        "ReplaceKeyPrefixWith": "government/organisations/companies-house/about/media-enquiries"
-    }
-  }
-]
-EOF
+    routing_rules = [
+      {
+        condition = {
+          key_prefix_equals = "arefiling/"
+        }
+
+        redirect = {
+          hostname                = "gov.uk"
+          protocol                = "https"
+          replace_key_prefix_with = "file-your-confirmation-statement-with-companies-house/"
+        }
+      },
+      {
+        condition = {
+          key_prefix_equals = "freedominformation/freedominfo.shtml"
+        }
+        
+        redirect = {
+          hostname                = "gov.uk"
+          protocol                = "https"
+          replace_key_prefix_with = "government/organisations/companies-house/about/personal-information-charter"
+        }
+      },
+      {
+        condition = {
+          key_prefix_equals = "pressDesk/introduction.shtml"
+        }
+
+        redirect = {
+          hostname                = "gov.uk"
+          protocol                = "https"
+          replace_key_prefix_with = "government/organisations/companies-house/about/media-enquiries"
+        }
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
Use a later terraform-aws-modules/s3-bucket/aws module version that contains a workaround to prevent toggling of configuration when using older providers and separate resources to define bucket logging.

Also, slightly refactors ACLs and website redirect config to work with the new module version.

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2825